### PR TITLE
Limit provider scope of NgxChessgroundService to its component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chessground",
-  "version": "11.1.1",
+  "version": "11.1.2",
   "description": "angular wrapper for ornicar/chessground",
   "scripts": {
     "tsc-lib": "tsc --project ./projects/ngx-chessground/tsconfig.lib.json",

--- a/projects/ngx-chessground/src/lib/ngx-chessground.component.ts
+++ b/projects/ngx-chessground/src/lib/ngx-chessground.component.ts
@@ -14,6 +14,7 @@ import { NgxChessgroundService } from './ngx-chessground.service';
   templateUrl: './ngx-chessground.component.html',
   styleUrls: ['./ngx-chessground.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [NgxChessgroundService]
 })
 export class NgxChessgroundComponent implements AfterViewInit {
   @Input()

--- a/projects/ngx-chessground/src/lib/ngx-chessground.service.spec.ts
+++ b/projects/ngx-chessground/src/lib/ngx-chessground.service.spec.ts
@@ -6,7 +6,9 @@ describe('NgxChessgroundService', () => {
   let service: NgxChessgroundService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [NgxChessgroundService]
+    });
     service = TestBed.inject(NgxChessgroundService);
   });
 

--- a/projects/ngx-chessground/src/lib/ngx-chessground.service.ts
+++ b/projects/ngx-chessground/src/lib/ngx-chessground.service.ts
@@ -9,9 +9,7 @@ import { eventListenersModule } from 'snabbdom/build/package/modules/eventlisten
 import { Chessground } from 'chessground';
 import { Api } from 'chessground/api';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class NgxChessgroundService {
   private patch = init([classModule, attributesModule, eventListenersModule]);
   private vnode!: VNode;


### PR DESCRIPTION
Currently the component can only be rendered once:

https://stackblitz.com/edit/angular-ivy-uerrrw

I think this is because the service has state that isn't reset correctly, i.e. the snabdom state

Simplest solution I think would be to attach the service lifecycle to the component